### PR TITLE
Be nice to those of us still using Python 2.7.

### DIFF
--- a/pystrich/qrcode/isodata.py
+++ b/pystrich/qrcode/isodata.py
@@ -1,6 +1,7 @@
 """ISO/IEC 18004:2006 tables and functions implementation"""
 
 import os.path
+import sys
 
 MAX_DATA_BITS = [
     128, 224, 352, 512, 688, 864, 992, 1232, 1456, 1728,
@@ -50,7 +51,10 @@ class MatrixInfo:
         filename = path + "/qrv" + str(version) + "_"
         filename += str(ecl) + ".dat"
 
-        unpack = list
+        if sys.version_info.major == 2:
+            unpack = lambda y: [ord(x) for x in y]
+        else:
+            unpack = list
 
         with open(filename, "rb") as fhndl:
             self.matrix_d = []


### PR DESCRIPTION
While Python 2.7 supports the Byte literal syntax, iteration will give characters, so `ord` is necessary.